### PR TITLE
Implement Ollama model warmup service and UI updates

### DIFF
--- a/apps/api/src/jobs/metadata.worker.ts
+++ b/apps/api/src/jobs/metadata.worker.ts
@@ -12,13 +12,18 @@ import * as schema from '../db/schema.js';
 import type { PaperlessClient } from '../paperless/client.js';
 import { Pipeline } from '../pipeline/pipeline.js';
 import type { StageDependencies } from '../pipeline/stage.interface.js';
+import type { OllamaWarmupService } from '../providers/llm/ollama-warmup.service.js';
 import { METADATA_QUEUE } from './queues.js';
+
+/** How long to pause (ms) before requeuing a job that aborted due to cold-start. */
+const COLD_START_REQUEUE_DELAY_MS = 15_000;
 
 export function createMetadataWorker(
     redis: IORedis,
     deps: StageDependencies,
     db: Database,
     paperlessClient: PaperlessClient,
+    warmup?: OllamaWarmupService,
 ): Worker<MetadataJobData> {
     const pipeline = new Pipeline();
     const log = getLogger();
@@ -27,6 +32,16 @@ export function createMetadataWorker(
         METADATA_QUEUE,
         async (job: Job<MetadataJobData>) => {
             const { documentId, mode, stages, useExistingOnly } = job.data;
+
+            // ── Health-gate: wait for Ollama to finish loading the model ───────
+            if (warmup) {
+                const state = warmup.currentState;
+                if (state === 'warming' || state === 'idle') {
+                    log.info({ documentId, jobId: job.id }, 'Waiting for Ollama model to warm up…');
+                    await warmup.waitUntilReady();
+                    log.info({ documentId, jobId: job.id }, 'Ollama model ready — proceeding');
+                }
+            }
 
             // Resolve effective flag: per-job override → global config
             const jobDeps: StageDependencies = {
@@ -75,6 +90,35 @@ export function createMetadataWorker(
     );
 
     worker.on('failed', (job, err) => {
+        const isColdStart = err instanceof Error && (
+            err.name === 'AbortError' ||
+            // ollama-ai-provider wraps the abort in an AI_APICallError
+            err.message.includes('aborted') ||
+            err.message.includes('ECONNREFUSED') ||
+            err.message.includes('ECONNRESET')
+        );
+
+        if (isColdStart && warmup) {
+            log.warn(
+                { jobId: job?.id, err },
+                `Metadata job failed due to Ollama cold-start. ` +
+                `Re-triggering warmup and requeueing in ${COLD_START_REQUEUE_DELAY_MS / 1000}s`,
+            );
+            // Re-arm the warmup so subsequent workers gate again.
+            warmup.reset();
+            void warmup.start();
+
+            // Requeue with a delay so the model has time to load.
+            if (job) {
+                setTimeout(() => {
+                    void job.retry().catch((retryErr) =>
+                        log.error({ jobId: job.id, retryErr }, 'Failed to requeue cold-start job'),
+                    );
+                }, COLD_START_REQUEUE_DELAY_MS);
+            }
+            return;
+        }
+
         log.error({ jobId: job?.id, err }, 'Metadata job failed');
         if (job?.id) {
             db.update(schema.jobs)

--- a/apps/api/src/jobs/polling.service.ts
+++ b/apps/api/src/jobs/polling.service.ts
@@ -8,6 +8,7 @@ import { getLogger } from '../config/logger.js';
 import type { Database } from '../db/connection.js';
 import * as schema from '../db/schema.js';
 import type { PaperlessClient } from '../paperless/client.js';
+import type { OllamaWarmupService } from '../providers/llm/ollama-warmup.service.js';
 import type { Queues } from './queues.js';
 
 interface TagQueueMapping {
@@ -26,6 +27,7 @@ export class PollingService {
         private readonly queues: Queues,
         private readonly config: AppConfig,
         private readonly db: Database,
+        private readonly warmup?: OllamaWarmupService,
     ) {
         this.mappings = [
             { tagName: config.MANUAL_TAG, queueName: 'metadata', jobMode: 'manual' },
@@ -50,19 +52,34 @@ export class PollingService {
 
     private async poll(): Promise<void> {
         const log = getLogger();
-        const allTags = await this.paperlessClient.getTags();
+        let allTags: Awaited<ReturnType<typeof this.paperlessClient.getTags>>;
+        try {
+            allTags = await this.paperlessClient.getTags();
+        } catch (err) {
+            log.error({ err }, 'Poller: failed to fetch tags from paperless-ngx — will retry next interval');
+            return;
+        }
 
         for (const mapping of this.mappings) {
             const tag = allTags.find((t) => t.name === mapping.tagName);
             if (!tag) continue;
 
-            const documents = await this.paperlessClient.getDocumentsByTag(tag.id);
+            let documents: Awaited<ReturnType<typeof this.paperlessClient.getDocumentsByTag>>;
+            try {
+                documents = await this.paperlessClient.getDocumentsByTag(tag.id);
+            } catch (err) {
+                log.error({ err, tag: mapping.tagName }, 'Poller: failed to fetch documents — skipping tag this interval');
+                continue;
+            }
             if (documents.length === 0) continue;
 
             log.info(
                 { tag: mapping.tagName, count: documents.length },
                 'Poller: found documents to process',
             );
+
+            // Kick off model warmup now that we know there's real work to do.
+            void this.warmup?.start();
 
             for (const doc of documents) {
                 const queue = this.queues[mapping.queueName];

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -22,6 +22,7 @@ import { createQueues } from './jobs/queues.js';
 import { PaperlessClient } from './paperless/client.js';
 import { PromptEngine } from './prompts/engine.js';
 import { createLLMProvider } from './providers/llm/factory.js';
+import { OllamaWarmupService } from './providers/llm/ollama-warmup.service.js';
 import { createOcrProvider, validateOcrModeCompatibility } from './providers/ocr/factory.js';
 import { SseService } from './sse/sse.service.js';
 
@@ -72,10 +73,23 @@ async function bootstrap() {
     const queues = createQueues(redis);
     const sse = new SseService();
 
-    createMetadataWorker(redis, stageDeps, db, paperlessClient);
+    // ── Ollama warmup (only when provider is ollama) ──────────────────
+    let warmup: OllamaWarmupService | undefined;
+    if (config.LLM_PROVIDER === 'ollama') {
+        const ollamaBase = (config.OLLAMA_HOST ?? 'http://localhost:11434').replace(/\/api\/?$/, '');
+        warmup = new OllamaWarmupService({
+            baseURL: ollamaBase,
+            model: config.LLM_MODEL,
+            warmupTimeoutMs: (config.OLLAMA_REQUEST_TIMEOUT_SECONDS ?? 600) * 1000,
+            sseService: sse,
+        });
+        log.info({ model: config.LLM_MODEL }, 'Ollama warmup service created (starts on first job enqueue)');
+    }
+
+    createMetadataWorker(redis, stageDeps, db, paperlessClient, warmup);
     // createOcrWorker(redis, stageDeps, db, paperlessClient); // Phase 2
 
-    const polling = new PollingService(paperlessClient, queues, config, db);
+    const polling = new PollingService(paperlessClient, queues, config, db, warmup);
     polling.start();
 
     // ── 5. HTTP server ────────────────────────────────────────────────
@@ -132,8 +146,8 @@ async function bootstrap() {
     const apiPrefix = '/api';
 
     await app.register(authRoutes, { prefix: apiPrefix, config });
-    await app.register(healthRoutes, { prefix: apiPrefix, paperlessClient, redis, db, version: getVersion(), config });
-    await app.register(documentRoutes, { prefix: apiPrefix, db, paperlessClient, queues, sse, config });
+    await app.register(healthRoutes, { prefix: apiPrefix, paperlessClient, redis, db, version: getVersion(), config, warmup });
+    await app.register(documentRoutes, { prefix: apiPrefix, db, paperlessClient, queues, sse, config, warmup });
     await app.register(jobRoutes, { prefix: apiPrefix, queues, sse });
     await app.register(promptRoutes, { prefix: apiPrefix, promptEngine });
     await app.register(analysisRoutes, { prefix: apiPrefix, queues, paperlessClient, llmProvider, promptEngine, config });

--- a/apps/api/src/providers/llm/ollama-warmup.service.ts
+++ b/apps/api/src/providers/llm/ollama-warmup.service.ts
@@ -1,0 +1,160 @@
+/**
+ * OllamaWarmupService — SRP: owns the Ollama model pre-warm lifecycle.
+ * DIP: depends on SseService interface, not on any concrete transport.
+ *
+ * Strategy:
+ *  1. On startup (and after every job completes) send a zero-token "ping" to
+ *     Ollama's /api/generate with keep_alive set. This triggers a model load
+ *     without generating any tokens.
+ *  2. The service tracks "ready" state and exposes a `waitUntilReady()` promise
+ *     so workers can gate themselves instead of racing the cold-start.
+ *  3. SSE events are emitted so the frontend can show a "warming up…" indicator.
+ */
+import { EventEmitter } from 'node:events';
+import { getLogger } from '../../config/logger.js';
+import type { SseService } from '../../sse/sse.service.js';
+
+export type WarmupState = 'idle' | 'warming' | 'ready' | 'error';
+
+export interface OllamaWarmupOptions {
+    /** Base URL of the Ollama instance, e.g. http://localhost:11434 */
+    baseURL: string;
+    /** Model name to pre-load, e.g. qwen3:14b */
+    model: string;
+    /**
+     * How long (ms) to wait for Ollama to load the model before giving up.
+     * Defaults to 10 minutes.
+     */
+    warmupTimeoutMs?: number;
+    /** Interval (ms) between warmup ping retries. Defaults to 5 s. */
+    retryIntervalMs?: number;
+    /** Optional SSE service to broadcast warmup state to connected clients. */
+    sseService?: SseService;
+}
+
+export class OllamaWarmupService extends EventEmitter {
+    private state: WarmupState = 'idle';
+    /** Resolves when the model is confirmed loaded, rejects on timeout/error. */
+    private readyPromise: Promise<void>;
+    private resolveReady!: () => void;
+    private rejectReady!: (err: Error) => void;
+
+    constructor(private readonly opts: OllamaWarmupOptions) {
+        super();
+        this.readyPromise = this.createReadyPromise();
+    }
+
+    get currentState(): WarmupState {
+        return this.state;
+    }
+
+    /**
+     * Await this to block until the model is confirmed loaded.
+     * Safe to call multiple times; resolves immediately if already ready.
+     */
+    waitUntilReady(): Promise<void> {
+        if (this.state === 'ready') return Promise.resolve();
+        return this.readyPromise;
+    }
+
+    /**
+     * Reset to a new readyPromise (e.g. after Ollama evicts the model).
+     * Called by the warmup loop to allow re-gating on the next cold start.
+     */
+    reset(): void {
+        if (this.state === 'ready') {
+            this.state = 'idle';
+            this.readyPromise = this.createReadyPromise();
+        }
+    }
+
+    /** Start the warmup ping loop. Resolves as soon as the model is loaded. */
+    async start(): Promise<void> {
+        if (this.state === 'warming' || this.state === 'ready') return;
+        this.setState('warming');
+        void this.runWarmupLoop();
+    }
+
+    // ─── Private ──────────────────────────────────────────────────────────────
+
+    private createReadyPromise(): Promise<void> {
+        return new Promise<void>((resolve, reject) => {
+            this.resolveReady = resolve;
+            this.rejectReady = reject;
+        });
+    }
+
+    private setState(next: WarmupState): void {
+        const prev = this.state;
+        this.state = next;
+        if (prev !== next) {
+            getLogger().info({ state: next, model: this.opts.model }, 'Ollama warmup state changed');
+            this.emit('stateChange', next);
+            this.opts.sseService?.broadcast({
+                type: 'ollama.warmup',
+                payload: { state: next, model: this.opts.model },
+            });
+        }
+    }
+
+    private async runWarmupLoop(): Promise<void> {
+        const log = getLogger();
+        const {
+            baseURL,
+            model,
+            warmupTimeoutMs = 10 * 60 * 1000,
+            retryIntervalMs = 5_000,
+        } = this.opts;
+
+        // Normalise base URL (strip /api suffix — the warmup hits /api/generate directly)
+        const apiBase = baseURL.replace(/\/api\/?$/, '');
+
+        const deadline = Date.now() + warmupTimeoutMs;
+
+        while (Date.now() < deadline) {
+            try {
+                log.debug({ model }, 'Ollama warmup: sending ping');
+
+                const res = await fetch(`${apiBase}/api/generate`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        model,
+                        prompt: '',  // empty prompt → no tokens generated, just loads the model
+                        stream: false,
+                    }),
+                    // keep_alive is intentionally omitted — Ollama uses its own
+                    // OLLAMA_KEEP_ALIVE server env var, which is the right place to set it.
+                    // Give each individual ping attempt its own abort deadline
+                    // (the outer loop handles total elapsed time).
+                    signal: AbortSignal.timeout(warmupTimeoutMs),
+                });
+
+                if (res.ok) {
+                    log.info({ model }, 'Ollama warmup: model is loaded and ready');
+                    this.setState('ready');
+                    this.resolveReady();
+                    return;
+                }
+
+                const body = await res.text().catch(() => '');
+                log.warn({ status: res.status, body, model }, 'Ollama warmup: unexpected response, retrying');
+            } catch (err: unknown) {
+                const isAbort = err instanceof Error && err.name === 'AbortError';
+                if (isAbort) break; // outer deadline hit
+                log.warn({ err, model }, 'Ollama warmup: ping failed, retrying');
+            }
+
+            await sleep(retryIntervalMs);
+        }
+
+        const error = new Error(`Ollama warmup timed out after ${warmupTimeoutMs / 1000}s for model "${model}"`);
+        log.error({ model }, error.message);
+        this.setState('error');
+        this.rejectReady(error);
+    }
+}
+
+function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/apps/api/src/routes/documents.routes.ts
+++ b/apps/api/src/routes/documents.routes.ts
@@ -9,6 +9,7 @@ import type { Database } from '../db/connection.js';
 import * as schema from '../db/schema.js';
 import type { Queues } from '../jobs/queues.js';
 import type { PaperlessClient } from '../paperless/client.js';
+import type { OllamaWarmupService } from '../providers/llm/ollama-warmup.service.js';
 import type { SseService } from '../sse/sse.service.js';
 
 interface DocumentsDeps {
@@ -17,6 +18,7 @@ interface DocumentsDeps {
     queues: Queues;
     sse: SseService;
     config: AppConfig;
+    warmup?: OllamaWarmupService;
 }
 
 export const documentRoutes: FastifyPluginAsync<DocumentsDeps> = async (fastify, opts) => {
@@ -100,6 +102,9 @@ export const documentRoutes: FastifyPluginAsync<DocumentsDeps> = async (fastify,
             const parsed = GenerateRequestSchema.safeParse(req.body);
             const stages = parsed.success ? (parsed.data.stages ?? []) : [];
             const useExistingOnly = parsed.success ? parsed.data.useExistingOnly : undefined;
+
+            // Trigger model warmup now that we know a job is about to be enqueued.
+            void opts.warmup?.start();
 
             const job = await queues.metadata.add(
                 'metadata',

--- a/apps/api/src/routes/health.routes.ts
+++ b/apps/api/src/routes/health.routes.ts
@@ -6,6 +6,7 @@ import type { FastifyPluginAsync } from 'fastify';
 import type { Redis as IORedis } from 'ioredis';
 import type { Database } from '../db/connection.js';
 import type { PaperlessClient } from '../paperless/client.js';
+import type { OllamaWarmupService } from '../providers/llm/ollama-warmup.service.js';
 
 interface HealthDeps {
     paperlessClient: PaperlessClient;
@@ -13,6 +14,7 @@ interface HealthDeps {
     db: Database;
     version: string;
     config: AppConfig;
+    warmup?: OllamaWarmupService;
 }
 
 async function checkOllama(
@@ -54,6 +56,7 @@ export const healthRoutes: FastifyPluginAsync<HealthDeps> = async (fastify, opts
         ]);
 
         const ollamaOk = ollamaResult === null ? null : ollamaResult.ok;
+        const warmupState = opts.warmup?.currentState ?? null;
         const allOk = paperlessNgx && redisOk && dbOk && (ollamaOk !== false);
 
         return reply.status(200).send({
@@ -62,6 +65,7 @@ export const healthRoutes: FastifyPluginAsync<HealthDeps> = async (fastify, opts
             checks: { paperlessNgx, redis: redisOk, database: dbOk, ollama: ollamaOk },
             ...(ollamaHost ? { ollamaModel: opts.config.LLM_MODEL } : {}),
             ...(ollamaResult?.error ? { ollamaError: ollamaResult.error } : {}),
+            ...(warmupState !== null ? { ollamaWarmup: warmupState } : {}),
         });
     });
 

--- a/apps/api/src/sse/sse.service.ts
+++ b/apps/api/src/sse/sse.service.ts
@@ -5,7 +5,7 @@ import type { FastifyReply } from 'fastify';
 import { getLogger } from '../config/logger.js';
 
 export interface SseEvent {
-    type: 'job.progress' | 'job.completed' | 'job.failed' | 'document.updated';
+    type: 'job.progress' | 'job.completed' | 'job.failed' | 'document.updated' | 'ollama.warmup';
     payload: Record<string, unknown>;
 }
 

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -120,12 +120,19 @@ function SidebarStatus() {
     (j) => j.status === 'active' || j.status === 'waiting',
   ) ?? [];
 
-  const checks: Array<{ key: string; label: string; sublabel?: string; tooltip?: string; ok: boolean | null }> = [
+  const checks: Array<{ key: string; label: string; sublabel?: string; tooltip?: string; ok: boolean | null; warming?: boolean }> = [
     { key: 'paperlessNgx', label: 'paperless-ngx',      ok: health?.checks.paperlessNgx ?? null },
     { key: 'redis',        label: 'Redis',               ok: health?.checks.redis        ?? null },
     { key: 'database',     label: t('dashboard.database'), ok: health?.checks.database   ?? null },
     ...(health?.checks.ollama !== undefined
-      ? [{ key: 'ollama', label: 'Ollama', sublabel: health?.ollamaModel, tooltip: health?.ollamaError, ok: health.checks.ollama }]
+      ? [{
+          key: 'ollama',
+          label: 'Ollama',
+          sublabel: health?.ollamaWarmup === 'warming' ? t('ollama.warmingStatus') : health?.ollamaModel,
+          tooltip: health?.ollamaError,
+          ok: health.checks.ollama,
+          warming: health?.ollamaWarmup === 'warming',
+        }]
       : []),
   ];
 
@@ -137,18 +144,19 @@ function SidebarStatus() {
 
       {/* Service indicators */}
       <ul className="space-y-1">
-        {checks.map(({ key, label, sublabel, tooltip, ok }) => (
+        {checks.map(({ key, label, sublabel, tooltip, ok, warming }) => (
           <li key={key} title={tooltip} className={cn('flex items-center gap-2', tooltip && 'cursor-help')}>
             <span
               className={cn(
                 'h-1.5 w-1.5 rounded-full shrink-0',
-                ok === null  ? 'bg-gray-600'  :
-                ok === true  ? 'bg-green-400' : 'bg-red-400',
+                warming          ? 'bg-amber-400 animate-pulse' :
+                ok === null      ? 'bg-gray-600' :
+                ok === true      ? 'bg-green-400' : 'bg-red-400',
               )}
             />
             <div className="min-w-0">
               <span className="text-xs text-gray-400 truncate block">{label}</span>
-              {sublabel && <span className="text-[10px] text-gray-600 truncate block">{sublabel}</span>}
+              {sublabel && <span className={cn('text-[10px] truncate block', warming ? 'text-amber-500' : 'text-gray-600')}>{sublabel}</span>}
               {tooltip && <span className="text-[10px] text-red-500 truncate block">{tooltip}</span>}
             </div>
           </li>

--- a/apps/web/src/hooks/useJobs.ts
+++ b/apps/web/src/hooks/useJobs.ts
@@ -5,6 +5,8 @@ import type { SseEvent } from '../lib/sse';
 import { useSse } from '../lib/sse';
 import { useNotifications } from '../store';
 
+const HEALTH_KEY = 'health';
+
 export const JOBS_KEY = 'jobs';
 
 export function useJobs(page = 1, pageSize = 25) {
@@ -73,12 +75,27 @@ export function useCancelJob() {
 /** Subscribe to live job progress via SSE and invalidate the jobs query. */
 export function useJobSseUpdates() {
     const qc = useQueryClient();
+    const { push } = useNotifications();
+    const { t } = useTranslation();
 
-    useSse<{ jobId: string; progress: number; status: string }>(
+    useSse<Record<string, unknown>>(
         '/api/events',
-        (event: SseEvent<{ jobId: string; progress: number; status: string }>) => {
-            if (event.type === 'job:progress' || event.type === 'job:complete' || event.type === 'job:failed') {
+        (event: SseEvent<Record<string, unknown>>) => {
+            if (event.type === 'job.progress' || event.type === 'job.completed' || event.type === 'job.failed') {
                 void qc.invalidateQueries({ queryKey: [JOBS_KEY] });
+            }
+
+            if (event.type === 'ollama.warmup') {
+                const state = event.payload['state'] as string | undefined;
+                // Invalidate health so the dashboard reflects the new warmup state.
+                void qc.invalidateQueries({ queryKey: [HEALTH_KEY] });
+                if (state === 'warming') {
+                    push({ kind: 'info', title: t('ollama.warming') });
+                } else if (state === 'ready') {
+                    push({ kind: 'success', title: t('ollama.ready') });
+                } else if (state === 'error') {
+                    push({ kind: 'error', title: t('ollama.error') });
+                }
             }
         },
     );

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -66,6 +66,8 @@ export interface HealthStatus {
     checks: Record<string, boolean | null>;
     ollamaModel?: string;
     ollamaError?: string;
+    /** Present only when LLM_PROVIDER=ollama. Reflects OllamaWarmupService state. */
+    ollamaWarmup?: 'idle' | 'warming' | 'ready' | 'error';
 }
 
 export const healthApi = {

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { AlertCircle, Briefcase, CheckCircle, FileText } from 'lucide-react';
+import { AlertCircle, Briefcase, CheckCircle, FileText, Loader2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { Badge, Card, CardHeader, Spinner } from '../components/ui';
 import { usePendingDocuments } from '../hooks/useDocuments';
@@ -36,8 +36,20 @@ export function DashboardPage() {
           <>
             <StatCard
               label={t('dashboard.systemStatus')}
-              value={health?.status === 'ok' ? t('common.ok') : t('common.degraded')}
-              icon={health?.status === 'ok' ? <CheckCircle className="text-green-500" /> : <AlertCircle className="text-red-500" />}
+              value={
+                health?.ollamaWarmup === 'warming'
+                  ? t('ollama.warmingStatus')
+                  : health?.status === 'ok'
+                    ? t('common.ok')
+                    : t('common.degraded')
+              }
+              icon={
+                health?.ollamaWarmup === 'warming'
+                  ? <Loader2 className="text-yellow-500 animate-spin" />
+                  : health?.status === 'ok'
+                    ? <CheckCircle className="text-green-500" />
+                    : <AlertCircle className="text-red-500" />
+              }
             />
             <StatCard
               label={t('dashboard.pendingDocuments')}

--- a/apps/web/src/pages/DocumentsPage.tsx
+++ b/apps/web/src/pages/DocumentsPage.tsx
@@ -1,11 +1,12 @@
 import type { DocumentSuggestions, PaperlessDocument } from '@paperless-llm/shared';
-import { useQueryClient } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { AlignLeft, Calendar, Check, ChevronDown, ChevronRight, FileText, FolderOpen, Loader2, Pencil, Plus, RefreshCw, Tag, Trash2, Type, User, X, Zap } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, Card, EmptyState, Spinner } from '../components/ui';
 import { DOCUMENTS_KEY, useApplySuggestions, useDeleteSuggestions, useDocumentSuggestions, useGenerateDocument, usePaperlessCorrespondents, usePaperlessDocumentTypes, usePaperlessTags, usePatchSuggestions, usePendingDocuments } from '../hooks/useDocuments';
 import { useActiveJob, useActiveJobForDocument } from '../hooks/useJobs';
+import { healthApi } from '../lib/api';
 import { cn, formatDate } from '../lib/utils';
 import { useUISettings } from '../store';
 
@@ -37,6 +38,8 @@ export function DocumentsPage() {
   const [page, setPage] = useState(1);
   const [expandedId, setExpandedId] = useState<number | null>(null);
   const { data, isLoading, refetch } = usePendingDocuments(page, 25);
+  const { data: health } = useQuery({ queryKey: ['health'], queryFn: healthApi.get, refetchInterval: 10_000 });
+  const warmingUp = health?.ollamaWarmup === 'warming';
 
   if (isLoading) {
     return (
@@ -57,6 +60,13 @@ export function DocumentsPage() {
         </Button>
       </div>
 
+      {warmingUp && (
+        <div className="flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-4 py-2.5 text-sm text-amber-700">
+          <Loader2 size={14} className="animate-spin shrink-0" />
+          <span>{t('ollama.warming')}</span>
+        </div>
+      )}
+
       {docs.length === 0 ? (
         <EmptyState
           icon={<FileText size={40} />}
@@ -71,6 +81,7 @@ export function DocumentsPage() {
               doc={doc}
               expanded={expandedId === doc.id}
               onToggle={() => setExpandedId(expandedId === doc.id ? null : doc.id)}
+              warmingUp={warmingUp}
             />
           ))}
         </div>
@@ -93,10 +104,11 @@ export function DocumentsPage() {
 
 // ─── Document row ─────────────────────────────────────────────────────────────
 
-function DocumentRow({ doc, expanded, onToggle }: {
+function DocumentRow({ doc, expanded, onToggle, warmingUp }: {
   doc: PaperlessDocument;
   expanded: boolean;
   onToggle: () => void;
+  warmingUp?: boolean;
 }) {
   const { t } = useTranslation();
   const qc = useQueryClient();
@@ -271,6 +283,7 @@ function DocumentRow({ doc, expanded, onToggle }: {
               currentStage={effectiveJob.currentStage ?? null}
               progress={effectiveJob.progress}
               status={effectiveJob.status}
+              warmingUp={warmingUp}
             />
           )}
 
@@ -332,11 +345,13 @@ function StageProgress({
   currentStage,
   progress,
   status,
+  warmingUp,
 }: {
   stages: string[];
   currentStage: string | null;
   progress: number;
   status: string;
+  warmingUp?: boolean;
 }) {
   const { t } = useTranslation();
 
@@ -344,6 +359,7 @@ function StageProgress({
   const currentIdx = currentStage ? stages.indexOf(currentStage) : -1;
 
   const statusLabel =
+    status === 'waiting' && warmingUp ? t('ollama.warming') :
     status === 'waiting'   ? t('documents.jobWaiting') :
     status === 'completed' ? t('documents.jobCompleted') :
     status === 'failed'    ? t('documents.jobFailed') :
@@ -354,7 +370,7 @@ function StageProgress({
     <div className="rounded-lg border border-gray-100 bg-gray-50 p-3 space-y-2">
       {/* Status line */}
       <div className="flex items-center gap-2">
-        <Loader2 size={13} className="text-primary-500 animate-spin shrink-0" />
+        <Loader2 size={13} className={cn('animate-spin shrink-0', status === 'waiting' && warmingUp ? 'text-amber-500' : 'text-primary-500')} />
         <span className="text-xs font-medium text-gray-600">{statusLabel}</span>
         <span className="ml-auto text-xs text-gray-400 tabular-nums">{progress}%</span>
       </div>

--- a/apps/web/src/pages/DocumentsPage.tsx
+++ b/apps/web/src/pages/DocumentsPage.tsx
@@ -462,7 +462,7 @@ function SuggestionsPanel({ docId, suggestions }: { docId: number; suggestions: 
   );
 
   return (
-    <div className="rounded-lg border border-gray-100 bg-gray-50/60 divide-y divide-gray-100 overflow-hidden">
+    <div className="rounded-lg border border-gray-100 bg-gray-50/60 divide-y divide-gray-100">
       {/* Header */}
       <div className="flex items-center gap-2 px-3 py-2">
         <span className="text-[11px] font-semibold uppercase tracking-wider text-gray-400">
@@ -512,7 +512,7 @@ function SuggestionsPanel({ docId, suggestions }: { docId: number; suggestions: 
       </div>
 
       {/* Tags */}
-      <div className="px-3 py-2.5 bg-white">
+      <div className="px-3 py-2.5 bg-white last:rounded-b-lg">
         <p className="flex items-center gap-1.5 text-[11px] font-medium text-gray-400 mb-2">
           <Tag size={11} />
           {t('documents.fields.tags')}
@@ -593,7 +593,7 @@ function SuggestionsPanel({ docId, suggestions }: { docId: number; suggestions: 
 
       {/* Summary */}
       {edited.summary && (
-        <div className="px-3 py-2.5 bg-white">
+        <div className="px-3 py-2.5 bg-white last:rounded-b-lg">
           <p className="flex items-center gap-1.5 text-[11px] font-medium text-gray-400 mb-1.5">
             <AlignLeft size={11} />
             {t('documents.fields.summary')}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,7 +100,6 @@ services:
       - .env
     environment:
       REDIS_URL: redis://redis:6379
-      PAPERLESS_BASE_URL: http://paperless-ngx:8000
       # All other settings (LLM_PROVIDER, LLM_MODEL, OCR_PROVIDER, AUTH_ENABLED, JWT_SECRET, …)
       # are loaded from .env — see .env.example for the full reference.
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,6 +73,10 @@ services:
   #     # Keep models loaded in VRAM for 2 hours after last request.
   #     # Use -1 to keep them loaded indefinitely.
   #     OLLAMA_KEEP_ALIVE: 2h
+  #     # How long to wait for the llama.cpp runner to load the model.
+  #     # Default is 5m — increase for larger models:
+  #     #   ≤7B → 5m, 14B → 10m, 32B → 15m, ≥70B → 30m
+  #     OLLAMA_LOAD_TIMEOUT: 10m
   #   ports:
   #     - "11434:11434"
   #   volumes:

--- a/docs/ollama-cold-start.md
+++ b/docs/ollama-cold-start.md
@@ -1,0 +1,264 @@
+# Ollama Cold-Start Handling
+
+When `LLM_PROVIDER=ollama` is configured, Ollama needs to load the model into GPU/CPU memory before it can serve requests. This load can take anywhere from a few seconds to several minutes depending on model size and hardware. If a job reaches the worker before the model is ready, Ollama returns an aborted or connection-reset error — a "cold start".
+
+This document describes how paperless-llm handles this transparently so no jobs are lost and users get clear feedback.
+
+---
+
+## Overview
+
+The solution has three layers:
+
+1. **`OllamaWarmupService`** — owns the model-load lifecycle; sends a zero-token ping to Ollama and waits for it to respond successfully.
+2. **Worker health-gate** — blocks any metadata job from executing until the service reports `ready`.
+3. **Cold-start recovery** — if a job slips through (e.g. Ollama evicted the model mid-run), the worker detects the error, re-arms the service, and requeues the job after a short delay.
+
+---
+
+## Warmup Lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> idle : service created at startup
+
+    idle --> warming : warmup.start() called
+    warming --> ready : Ollama /api/generate responds 200
+    warming --> error : timeout exceeded (default 10 min)
+
+    ready --> idle : warmup.reset() called\n(after a cold-start failure)
+    idle --> warming : warmup.start() called again
+    error --> [*]
+```
+
+**States:**
+
+| State | Meaning |
+|-------|---------|
+| `idle` | Service created, no warmup attempt yet (or reset after eviction) |
+| `warming` | Ping loop active — Ollama is loading the model |
+| `ready` | Ollama confirmed the model is loaded; workers proceed normally |
+| `error` | Warmup timed out; jobs will fail until the issue is resolved |
+
+---
+
+## Trigger Points
+
+Warmup is **lazy**: the service is created at startup but `start()` is only called when there is real work to do, to avoid heating the model when the application is idle.
+
+```mermaid
+sequenceDiagram
+    participant Poll as PollingService
+    participant Doc as POST /api/documents/:id/process
+    participant WS as OllamaWarmupService
+    participant W as MetadataWorker
+    participant Ol as Ollama
+
+    alt Automatic polling finds tagged documents
+        Poll->>WS: warmup.start()
+    else Manual process button clicked
+        Doc->>WS: warmup.start()
+    end
+
+    WS->>Ol: POST /api/generate { model, prompt: "" }
+    note over Ol: loads model into memory
+    Ol-->>WS: 200 OK
+    WS->>WS: setState('ready')
+    WS-->>SSE: broadcast { type: 'ollama.warmup', state: 'ready' }
+```
+
+---
+
+## Worker Health-Gate
+
+Before executing any pipeline stage, the worker checks the warmup state. If Ollama is still loading, the job waits in place rather than proceeding and failing.
+
+```mermaid
+sequenceDiagram
+    participant BQ as BullMQ Queue
+    participant W as MetadataWorker
+    participant WS as OllamaWarmupService
+    participant P as Pipeline
+
+    BQ->>W: job dequeued
+    W->>WS: currentState?
+
+    alt state === 'warming' or 'idle'
+        W->>WS: waitUntilReady()
+        note over W: suspends — awaits Promise
+        WS-->>W: resolves when ready
+    end
+
+    W->>P: pipeline.run(...)
+    P-->>W: suggestions
+    W->>W: persist to DB
+```
+
+`waitUntilReady()` returns immediately if the state is already `ready`, so there is zero overhead for jobs that arrive after the model is loaded.
+
+---
+
+## Cold-Start Recovery
+
+Ollama can evict a model from memory between jobs (controlled by `OLLAMA_KEEP_ALIVE` on the Ollama server). If a job starts, sends an LLM request, and the model has been evicted, Ollama responds with an abort or connection error.
+
+```mermaid
+sequenceDiagram
+    participant W as MetadataWorker
+    participant WS as OllamaWarmupService
+    participant BQ as BullMQ
+
+    W->>W: pipeline.run() — LLM request fails
+    note over W: AbortError / ECONNREFUSED / ECONNRESET
+
+    W->>W: detect isColdStart = true
+    W->>WS: warmup.reset()
+    note over WS: state: ready → idle, new Promise created
+    W->>WS: warmup.start()
+    note over WS: state: idle → warming, ping loop restarts
+
+    W->>BQ: job.retry() after 15 s delay
+    note over BQ: job re-enters queue; worker\nhealth-gate blocks it until ready
+```
+
+**Cold-start error detection** matches:
+- `err.name === 'AbortError'`
+- `err.message` includes `aborted`
+- `err.message` includes `ECONNREFUSED`
+- `err.message` includes `ECONNRESET`
+
+The 15-second requeue delay (`COLD_START_REQUEUE_DELAY_MS`) gives Ollama time to start loading before the job is picked up again.
+
+---
+
+## Health Endpoint
+
+`GET /api/health` includes the warmup state when `LLM_PROVIDER=ollama`:
+
+```json
+{
+  "status": "ok",
+  "checks": {
+    "paperlessNgx": true,
+    "redis": true,
+    "database": true,
+    "ollama": true
+  },
+  "ollamaModel": "qwen3:14b",
+  "ollamaWarmup": "warming"
+}
+```
+
+`ollamaWarmup` mirrors the `WarmupState` type: `idle | warming | ready | error`. The field is absent when the provider is not Ollama.
+
+---
+
+## SSE Events
+
+Warmup state changes are broadcast to all connected frontend clients via Server-Sent Events:
+
+```json
+{
+  "type": "ollama.warmup",
+  "payload": {
+    "state": "warming",
+    "model": "qwen3:14b"
+  }
+}
+```
+
+The frontend (`useJobSseUpdates`) listens for this event, invalidates the health query, and shows toast notifications:
+
+| State | Toast |
+|-------|-------|
+| `warming` | ℹ️ "LLM model loading into memory…" |
+| `ready` | ✅ "LLM model ready" |
+| `error` | ❌ "LLM model failed to load" |
+
+---
+
+## Frontend Indicators
+
+When `ollamaWarmup === 'warming'` the UI surfaces this in three places:
+
+**Sidebar status indicator**
+- The Ollama dot turns amber and pulses (`animate-pulse`)
+- The sublabel changes from the model name to "Warming up"
+
+**Dashboard stat card**
+- The system status value changes to "Warming up"
+- The icon becomes a spinning amber `Loader2`
+
+**Documents page**
+- A banner appears: "LLM model loading into memory…"
+- Each waiting job's stage-progress spinner turns amber and shows "Warming up" instead of "Waiting"
+
+---
+
+## Configuration
+
+| Environment variable | Default | Description |
+|----------------------|---------|-------------|
+| `LLM_PROVIDER` | — | Must be `ollama` for the warmup service to be created |
+| `OLLAMA_HOST` | `http://localhost:11434` | Ollama base URL (the warmup service strips any `/api` suffix) |
+| `LLM_MODEL` | — | Model name sent to `/api/generate` for the zero-token ping |
+| `OLLAMA_REQUEST_TIMEOUT_SECONDS` | `600` | Also used as `warmupTimeoutMs`; controls how long the ping loop runs before giving up |
+
+The warmup timeout mirrors `OLLAMA_REQUEST_TIMEOUT_SECONDS` so a single env var covers both the per-request LLM timeout and the total time allowed for a cold start.
+
+> **Tip:** Control how long Ollama keeps the model in memory between jobs with the `OLLAMA_KEEP_ALIVE` environment variable on the Ollama server (e.g. `OLLAMA_KEEP_ALIVE=24h`). A longer keep-alive reduces cold starts at the cost of VRAM.
+
+---
+
+## Troubleshooting
+
+### "timed out waiting for llama runner to start: context canceled"
+
+```
+time=… level=ERROR source=sched.go:571 msg="error loading llama server"
+  error="timed out waiting for llama runner to start: context canceled"
+```
+
+This error comes from **Ollama's own internal scheduler** (`sched.go`), not from paperless-llm. It means Ollama gave up waiting for the `llama.cpp` runner subprocess to become ready before our warmup ping even got a response.
+
+**Two separate timeouts are in play:**
+
+```
+paperless-llm warmup ping
+│
+▼  OLLAMA_REQUEST_TIMEOUT_SECONDS (default 600 s)   ← our app-level timeout
+│
+└──► Ollama /api/generate
+       │
+       ▼  OLLAMA_LOAD_TIMEOUT (default 5 m)          ← Ollama-internal timeout
+          llama.cpp runner loading model…
+```
+
+If the model takes longer than `OLLAMA_LOAD_TIMEOUT` to load into memory, Ollama cancels the runner and returns an error. Our warmup service will retry after 5 seconds, but each retry triggers another load attempt that also hits the same wall.
+
+**Fix:** Increase `OLLAMA_LOAD_TIMEOUT` in the Ollama container environment. The value accepts Go duration syntax.
+
+```yaml
+# docker-compose.yml — Ollama service
+services:
+  ollama:
+    image: ollama/ollama
+    environment:
+      OLLAMA_LOAD_TIMEOUT: 10m   # increase from the 5 m default
+```
+
+Common values by model size:
+
+| Model size | Suggested `OLLAMA_LOAD_TIMEOUT` |
+|------------|--------------------------------|
+| ≤ 7 B | `5m` (default) |
+| 14 B | `10m` |
+| 32 B | `15m` |
+| ≥ 70 B | `30m` |
+
+Also make sure `OLLAMA_REQUEST_TIMEOUT_SECONDS` in paperless-llm is **greater than** `OLLAMA_LOAD_TIMEOUT`, otherwise paperless-llm's own timeout fires first:
+
+```env
+# paperless-llm
+OLLAMA_REQUEST_TIMEOUT_SECONDS=900  # 15 min — must exceed OLLAMA_LOAD_TIMEOUT
+```

--- a/packages/shared/src/locales/de.json
+++ b/packages/shared/src/locales/de.json
@@ -194,6 +194,12 @@
         "saveFailed": "Speichern fehlgeschlagen",
         "resetFailed": "Zurücksetzen fehlgeschlagen"
     },
+    "ollama": {
+        "warming": "LLM-Modell wird in den Speicher geladen…",
+        "ready": "LLM-Modell bereit",
+        "error": "LLM-Modell konnte nicht geladen werden",
+        "warmingStatus": "Wird aufgewärmt"
+    },
     "login": {
         "title": "paperless-llm",
         "subtitle": "Mit Ihren Paperless-ngx-Zugangsdaten anmelden",

--- a/packages/shared/src/locales/en.json
+++ b/packages/shared/src/locales/en.json
@@ -194,6 +194,12 @@
         "saveFailed": "Save failed",
         "resetFailed": "Reset failed"
     },
+    "ollama": {
+        "warming": "LLM model loading into memory…",
+        "ready": "LLM model ready",
+        "error": "LLM model failed to load",
+        "warmingStatus": "Warming up"
+    },
     "login": {
         "title": "paperless-llm",
         "subtitle": "Sign in with your Paperless-ngx credentials",


### PR DESCRIPTION
This pull request introduces a robust "Ollama model warmup" mechanism to improve reliability and user experience when using the Ollama LLM provider. The new `OllamaWarmupService` proactively loads the model before jobs are processed, provides state tracking (idle, warming, ready, error), exposes state to the frontend via SSE and health checks, and ensures jobs are re-queued if they fail due to cold starts. The UI now clearly indicates when the model is warming up.

Key changes include:

**Ollama Model Warmup Service Implementation:**

- Added a new `OllamaWarmupService` class that manages the Ollama model's lifecycle, sending "ping" requests to pre-load the model, tracking readiness, and broadcasting state changes via SSE. It exposes a `waitUntilReady()` promise for workers to block until the model is loaded. (`apps/api/src/providers/llm/ollama-warmup.service.ts`)

**Backend Integration and Reliability Improvements:**

- Integrated `OllamaWarmupService` into the metadata worker, polling service, and document/job routes. Jobs now wait for the model to be ready before processing, and failed jobs due to cold starts are automatically retried after a delay, re-triggering warmup. (`apps/api/src/jobs/metadata.worker.ts`, `apps/api/src/jobs/polling.service.ts`, `apps/api/src/main.ts`, `apps/api/src/routes/documents.routes.ts`) [[1]](diffhunk://#diff-532e80f8d81e0bb19c9df66a0bcfdab857b77091e2c112d8f5e119108c061fd6R15-R26) [[2]](diffhunk://#diff-532e80f8d81e0bb19c9df66a0bcfdab857b77091e2c112d8f5e119108c061fd6R36-R45) [[3]](diffhunk://#diff-532e80f8d81e0bb19c9df66a0bcfdab857b77091e2c112d8f5e119108c061fd6R93-R121) [[4]](diffhunk://#diff-498b20eea0c4ca1c2f7fbbfe7cd82483b19655ed7ee21cc6bac92998a51a01d1R11) [[5]](diffhunk://#diff-498b20eea0c4ca1c2f7fbbfe7cd82483b19655ed7ee21cc6bac92998a51a01d1R30) [[6]](diffhunk://#diff-498b20eea0c4ca1c2f7fbbfe7cd82483b19655ed7ee21cc6bac92998a51a01d1L53-R83) [[7]](diffhunk://#diff-32c5294dd7ca131397ef57a87c3e0cf38ea5c2e4ca0061c602e73f7f00514c1aR25) [[8]](diffhunk://#diff-32c5294dd7ca131397ef57a87c3e0cf38ea5c2e4ca0061c602e73f7f00514c1aL75-R92) [[9]](diffhunk://#diff-32c5294dd7ca131397ef57a87c3e0cf38ea5c2e4ca0061c602e73f7f00514c1aL135-R150) [[10]](diffhunk://#diff-99ba8d9ae13e03db906355b64bd7de03c69fe8eb76339215344c425151ff061bR12) [[11]](diffhunk://#diff-99ba8d9ae13e03db906355b64bd7de03c69fe8eb76339215344c425151ff061bR21) [[12]](diffhunk://#diff-99ba8d9ae13e03db906355b64bd7de03c69fe8eb76339215344c425151ff061bR106-R108)

**Health and SSE Reporting:**

- Extended health check and SSE event infrastructure to report Ollama warmup state to clients, allowing the frontend to display accurate status. (`apps/api/src/routes/health.routes.ts`, `apps/api/src/sse/sse.service.ts`) [[1]](diffhunk://#diff-35257a17b5b4560bf85f4c711ff818007b8d61f75b7ba8fbd727faea9d625626R9-R17) [[2]](diffhunk://#diff-35257a17b5b4560bf85f4c711ff818007b8d61f75b7ba8fbd727faea9d625626R59) [[3]](diffhunk://#diff-35257a17b5b4560bf85f4c711ff818007b8d61f75b7ba8fbd727faea9d625626R68) [[4]](diffhunk://#diff-93466a86e16f98396527b14d5318316602afd4cc374365ae3634e3d906691f5cL8-R8)

**Frontend User Experience:**

- Updated the sidebar status UI to show a pulsing amber indicator and a "warming up" label when the Ollama model is loading, giving users clear feedback about LLM readiness. (`apps/web/src/components/Sidebar.tsx`) [[1]](diffhunk://#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1L123-R135) [[2]](diffhunk://#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1L140-R159)