### PR TITLE
Adjust styling for SuggestionsPanel component

### DIFF
--- a/apps/web/src/pages/DocumentsPage.tsx
+++ b/apps/web/src/pages/DocumentsPage.tsx
@@ -462,7 +462,7 @@ function SuggestionsPanel({ docId, suggestions }: { docId: number; suggestions: 
   );
 
   return (
-    <div className="rounded-lg border border-gray-100 bg-gray-50/60 divide-y divide-gray-100 overflow-hidden">
+    <div className="rounded-lg border border-gray-100 bg-gray-50/60 divide-y divide-gray-100">
       {/* Header */}
       <div className="flex items-center gap-2 px-3 py-2">
         <span className="text-[11px] font-semibold uppercase tracking-wider text-gray-400">
@@ -512,7 +512,7 @@ function SuggestionsPanel({ docId, suggestions }: { docId: number; suggestions: 
       </div>
 
       {/* Tags */}
-      <div className="px-3 py-2.5 bg-white">
+      <div className="px-3 py-2.5 bg-white last:rounded-b-lg">
         <p className="flex items-center gap-1.5 text-[11px] font-medium text-gray-400 mb-2">
           <Tag size={11} />
           {t('documents.fields.tags')}
@@ -593,7 +593,7 @@ function SuggestionsPanel({ docId, suggestions }: { docId: number; suggestions: 
 
       {/* Summary */}
       {edited.summary && (
-        <div className="px-3 py-2.5 bg-white">
+        <div className="px-3 py-2.5 bg-white last:rounded-b-lg">
           <p className="flex items-center gap-1.5 text-[11px] font-medium text-gray-400 mb-1.5">
             <AlignLeft size={11} />
             {t('documents.fields.summary')}


### PR DESCRIPTION
This pull request makes minor UI improvements to the `SuggestionsPanel` component in `DocumentsPage.tsx`, focusing on border radius styling for a more polished appearance.

UI improvements:

* Removed the unnecessary `overflow-hidden` class from the panel container to prevent unwanted clipping of content.
* Added the `last:rounded-b-lg` class to the tags and summary sections, ensuring that the bottom corners are rounded when these sections appear last in the panel. [[1]](diffhunk://#diff-788f45d03315144a4d5ebf33b527fb1312eb7371a5c96349c4d8c71870efc472L515-R515) [[2]](diffhunk://#diff-788f45d03315144a4d5ebf33b527fb1312eb7371a5c96349c4d8c71870efc472L596-R596)