### PR TITLE
Enhance tag suggestions and update Ollama warmup service

### DIFF
--- a/apps/api/src/db/connection.ts
+++ b/apps/api/src/db/connection.ts
@@ -50,6 +50,9 @@ export function createDatabase() {
         created_date TEXT,
         custom_fields TEXT,
         summary TEXT,
+        new_tags TEXT,
+        new_correspondent TEXT,
+        new_document_type TEXT,
         created_at INTEGER NOT NULL DEFAULT (unixepoch()),
         applied_at INTEGER
       );
@@ -76,6 +79,14 @@ export function createDatabase() {
         created_at INTEGER NOT NULL DEFAULT (unixepoch())
       );
     `);
+        // Add new columns to existing suggestions tables (ignore error if already present)
+        for (const col of [
+            'ALTER TABLE suggestions ADD COLUMN new_tags TEXT',
+            'ALTER TABLE suggestions ADD COLUMN new_correspondent TEXT',
+            'ALTER TABLE suggestions ADD COLUMN new_document_type TEXT',
+        ]) {
+            try { sqlite.exec(col); } catch { /* column already exists */ }
+        }
     }
 
     return db;

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -18,6 +18,9 @@ export const suggestions = sqliteTable('suggestions', {
     createdDate: text('created_date'),
     customFields: text('custom_fields', { mode: 'json' }),
     summary: text('summary'),
+    newTags: text('new_tags', { mode: 'json' }).$type<string[]>(),
+    newCorrespondent: text('new_correspondent'),
+    newDocumentType: text('new_document_type'),
     createdAt: integer('created_at', { mode: 'timestamp' })
         .notNull()
         .default(sql`(unixepoch())`),

--- a/apps/api/src/jobs/metadata.worker.ts
+++ b/apps/api/src/jobs/metadata.worker.ts
@@ -79,6 +79,9 @@ export function createMetadataWorker(
                     createdDate: result.suggestions.createdDate ?? null,
                     customFields: result.suggestions.customFields ?? null,
                     summary: result.suggestions.summary ?? null,
+                    newTags: result.suggestions.newTags?.length ? result.suggestions.newTags : null,
+                    newCorrespondent: result.suggestions.newCorrespondent ?? null,
+                    newDocumentType: result.suggestions.newDocumentType ?? null,
                 })
                 .onConflictDoNothing();
 

--- a/apps/api/src/paperless/client.ts
+++ b/apps/api/src/paperless/client.ts
@@ -126,7 +126,12 @@ export class PaperlessClient {
         return this.fetchAll<PaperlessDocumentType>('/document_types/');
     }
 
-    // ─── Apply Suggestions ─────────────────────────────────────────────
+    async ensureDocumentType(name: string): Promise<PaperlessDocumentType> {
+        const existing = (await this.getDocumentTypes()).find((dt) => dt.name === name);
+        if (existing) return existing;
+        const res = await this.http.post<PaperlessDocumentType>('/document_types/', { name });
+        return res.data;
+    }
 
     async applySuggestions(doc: PaperlessDocument, suggestions: Partial<DocumentSuggestions>): Promise<PaperlessDocument> {
         const log = getLogger();
@@ -150,9 +155,8 @@ export class PaperlessClient {
 
         if ('documentType' in suggestions) {
             if (suggestions.documentType) {
-                const types = await this.getDocumentTypes();
-                const match = types.find((dt) => dt.name === suggestions.documentType);
-                updates.document_type = match?.id ?? null;
+                const entity = await this.ensureDocumentType(suggestions.documentType);
+                updates.document_type = entity.id;
             } else {
                 updates.document_type = null;
             }

--- a/apps/api/src/pipeline/stages/correspondent.stage.ts
+++ b/apps/api/src/pipeline/stages/correspondent.stage.ts
@@ -32,18 +32,24 @@ export class CorrespondentStage extends BasePipelineStage {
 
         const trimmed = raw.trim();
         let correspondent: string | null;
+        let newCorrespondent: string | null = null;
 
         if (trimmed === 'null' || trimmed === '') {
             correspondent = null;
-        } else if (deps.useExistingOnly && !availableNames.includes(trimmed)) {
-            // When restricted to existing items, discard names not in paperless-ngx
+        } else if (availableNames.includes(trimmed)) {
+            // Exact match with an existing correspondent
+            correspondent = trimmed;
+        } else if (deps.useExistingOnly) {
+            // When restricted to existing items, discard unknown names
             correspondent = null;
         } else {
-            correspondent = trimmed;
+            // New correspondent suggested by the LLM — keep it separate for user review
+            correspondent = null;
+            newCorrespondent = trimmed;
         }
 
         return updateContext(ctx, {
-            suggestions: { ...ctx.suggestions, correspondent },
+            suggestions: { ...ctx.suggestions, correspondent, newCorrespondent },
         });
     }
 }

--- a/apps/api/src/pipeline/stages/document-type.stage.ts
+++ b/apps/api/src/pipeline/stages/document-type.stage.ts
@@ -31,18 +31,24 @@ export class DocumentTypeStage extends BasePipelineStage {
 
         const trimmed = raw.trim();
         let documentType: string | null;
+        let newDocumentType: string | null = null;
 
         if (trimmed === 'null' || trimmed === '') {
             documentType = null;
-        } else if (deps.useExistingOnly && !availableNames.includes(trimmed)) {
-            // When restricted to existing items, discard types not in paperless-ngx
+        } else if (availableNames.includes(trimmed)) {
+            // Exact match with an existing document type
+            documentType = trimmed;
+        } else if (deps.useExistingOnly) {
+            // When restricted to existing items, discard unknown types
             documentType = null;
         } else {
-            documentType = trimmed;
+            // New document type suggested by the LLM — keep it separate for user review
+            documentType = null;
+            newDocumentType = trimmed;
         }
 
         return updateContext(ctx, {
-            suggestions: { ...ctx.suggestions, documentType },
+            suggestions: { ...ctx.suggestions, documentType, newDocumentType },
         });
     }
 }

--- a/apps/api/src/pipeline/stages/tags.stage.ts
+++ b/apps/api/src/pipeline/stages/tags.stage.ts
@@ -38,22 +38,24 @@ export class TagsStage extends BasePipelineStage {
 
         const match = TAG_ARRAY_REGEX.exec(raw);
         let tags: string[] = [];
+        let newTags: string[] = [];
         if (match) {
             try {
                 const parsed: unknown = JSON.parse(match[0]);
                 if (Array.isArray(parsed)) {
-                    tags = parsed
-                        .filter((t): t is string => typeof t === 'string')
-                        // When useExistingOnly, keep only tags that already exist
-                        .filter((t) => !deps.useExistingOnly || availableTagNames.includes(t));
+                    const all = parsed.filter((t): t is string => typeof t === 'string');
+                    // Split into existing (already in paperless) and new (not yet created)
+                    tags = all.filter((t) => availableTagNames.includes(t));
+                    newTags = deps.useExistingOnly ? [] : all.filter((t) => !availableTagNames.includes(t));
                 }
             } catch {
                 tags = [];
+                newTags = [];
             }
         }
 
         return updateContext(ctx, {
-            suggestions: { ...ctx.suggestions, tags },
+            suggestions: { ...ctx.suggestions, tags, newTags },
         });
     }
 }

--- a/apps/api/src/providers/llm/ollama-warmup.service.ts
+++ b/apps/api/src/providers/llm/ollama-warmup.service.ts
@@ -120,8 +120,13 @@ export class OllamaWarmupService extends EventEmitter {
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({
                         model,
-                        prompt: '',  // empty prompt → no tokens generated, just loads the model
+                        prompt: 'Hi',
                         stream: false,
+                        // Disable thinking mode (Ollama 0.7+) so qwen3/deepseek-r1
+                        // and other reasoning models don't spend time generating
+                        // a <think> block before returning.
+                        think: false,
+                        options: { num_predict: 1 },
                     }),
                     // keep_alive is intentionally omitted — Ollama uses its own
                     // OLLAMA_KEEP_ALIVE server env var, which is the right place to set it.

--- a/apps/api/src/routes/documents.routes.ts
+++ b/apps/api/src/routes/documents.routes.ts
@@ -89,6 +89,9 @@ export const documentRoutes: FastifyPluginAsync<DocumentsDeps> = async (fastify,
             createdDate: latest.createdDate,
             customFields: latest.customFields,
             summary: latest.summary,
+            newTags: latest.newTags,
+            newCorrespondent: latest.newCorrespondent,
+            newDocumentType: latest.newDocumentType,
         };
     });
 
@@ -190,6 +193,9 @@ export const documentRoutes: FastifyPluginAsync<DocumentsDeps> = async (fastify,
             if (body.documentType !== undefined) updates['documentType'] = body.documentType;
             if (body.createdDate !== undefined) updates['createdDate'] = body.createdDate;
             if (body.summary !== undefined) updates['summary'] = body.summary;
+            if (body.newTags !== undefined) updates['newTags'] = body.newTags;
+            if (body.newCorrespondent !== undefined) updates['newCorrespondent'] = body.newCorrespondent;
+            if (body.newDocumentType !== undefined) updates['newDocumentType'] = body.newDocumentType;
 
             if (Object.keys(updates).length === 0) return reply.badRequest('No fields to update');
 

--- a/apps/web/src/pages/DocumentsPage.tsx
+++ b/apps/web/src/pages/DocumentsPage.tsx
@@ -182,11 +182,11 @@ function DocumentRow({ doc, expanded, onToggle, warmingUp }: {
   const effectiveJob = userJobRunning ? activeJob : pollerJob;
 
   return (
-    <Card className="p-0 overflow-hidden">
+    <Card className="p-0 overflow-visible">
       {/* Header row */}
       <button
         onClick={onToggle}
-        className="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-gray-50 transition-colors"
+        className="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-gray-50 transition-colors rounded-t-lg"
       >
         {expanded ? <ChevronDown size={16} className="text-gray-400" /> : <ChevronRight size={16} className="text-gray-400" />}
         <FileText size={16} className="text-primary-500 shrink-0" />
@@ -470,6 +470,35 @@ function SuggestionsPanel({ docId, suggestions }: { docId: number; suggestions: 
     addTagInputRef.current?.focus();
   }
 
+  function acceptNewTag(tag: string) {
+    const newTags = (edited.newTags ?? []).filter((t) => t !== tag);
+    const tags = [...(edited.tags ?? []), tag];
+    saveField({ tags, newTags });
+  }
+
+  function dismissNewTag(tag: string) {
+    const newTags = (edited.newTags ?? []).filter((t) => t !== tag);
+    saveField({ newTags });
+  }
+
+  function acceptNewCorrespondent() {
+    if (!edited.newCorrespondent) return;
+    saveField({ correspondent: edited.newCorrespondent, newCorrespondent: null });
+  }
+
+  function dismissNewCorrespondent() {
+    saveField({ newCorrespondent: null });
+  }
+
+  function acceptNewDocumentType() {
+    if (!edited.newDocumentType) return;
+    saveField({ documentType: edited.newDocumentType, newDocumentType: null });
+  }
+
+  function dismissNewDocumentType() {
+    saveField({ newDocumentType: null });
+  }
+
   // Filtered paperless tags: match search term and not already selected
   const filteredTags = allPaperlessTags.filter(
     (t) =>
@@ -505,6 +534,9 @@ function SuggestionsPanel({ docId, suggestions }: { docId: number; suggestions: 
             value={edited.correspondent ?? null}
             icon={<User size={11} />}
             options={allCorrespondents.map((c) => c.name)}
+            newSuggestion={edited.newCorrespondent ?? null}
+            onAcceptNew={acceptNewCorrespondent}
+            onDismissNew={dismissNewCorrespondent}
             onSave={(v) => saveField({ correspondent: v })}
           />
         </div>
@@ -514,6 +546,9 @@ function SuggestionsPanel({ docId, suggestions }: { docId: number; suggestions: 
             value={edited.documentType ?? null}
             icon={<FolderOpen size={11} />}
             options={allDocumentTypes.map((dt) => dt.name)}
+            newSuggestion={edited.newDocumentType ?? null}
+            onAcceptNew={acceptNewDocumentType}
+            onDismissNew={dismissNewDocumentType}
             onSave={(v) => saveField({ documentType: v })}
           />
         </div>
@@ -544,6 +579,32 @@ function SuggestionsPanel({ docId, suggestions }: { docId: number; suggestions: 
                 onClick={() => removeTag(tag)}
                 className="ml-0.5 flex h-3.5 w-3.5 items-center justify-center rounded-full text-blue-400 hover:bg-blue-200 hover:text-blue-700 transition-colors"
                 aria-label={`Remove tag ${tag}`}
+              >
+                <X size={8} strokeWidth={3} />
+              </button>
+            </span>
+          ))}
+          {/* New (not-yet-existing) tag suggestions */}
+          {(edited.newTags ?? []).map((tag) => (
+            <span
+              key={`new-${tag}`}
+              className="inline-flex items-center gap-0.5 rounded-full bg-amber-50 border border-amber-300 text-amber-700 text-xs font-medium pl-2 pr-1 py-0.5"
+              title={t('documents.newSuggestionHint')}
+            >
+              <span className="mr-0.5 text-[9px] font-bold uppercase tracking-wide opacity-70">{t('documents.newBadge')}</span>
+              {tag}
+              <button
+                onClick={() => acceptNewTag(tag)}
+                className="ml-0.5 flex h-3.5 w-3.5 items-center justify-center rounded-full text-amber-500 hover:bg-amber-200 hover:text-amber-800 transition-colors"
+                aria-label={`Accept new tag ${tag}`}
+                title={t('documents.acceptNew')}
+              >
+                <Plus size={8} strokeWidth={3} />
+              </button>
+              <button
+                onClick={() => dismissNewTag(tag)}
+                className="flex h-3.5 w-3.5 items-center justify-center rounded-full text-amber-400 hover:bg-amber-200 hover:text-amber-700 transition-colors"
+                aria-label={`Dismiss new tag ${tag}`}
               >
                 <X size={8} strokeWidth={3} />
               </button>
@@ -621,6 +682,40 @@ function SuggestionsPanel({ docId, suggestions }: { docId: number; suggestions: 
   );
 }
 
+// ─── New suggestion hint ──────────────────────────────────────────────────────
+
+function NewSuggestionHint({ name, onAccept, onDismiss }: {
+  name: string;
+  onAccept?: () => void;
+  onDismiss?: () => void;
+}) {
+  const { t } = useTranslation();
+  return (
+    <div className="mt-1.5 flex items-center gap-1.5 rounded border border-amber-200 bg-amber-50 px-2 py-1">
+      <span className="text-[9px] font-bold uppercase tracking-wide text-amber-500">{t('documents.newBadge')}</span>
+      <span className="flex-1 truncate text-xs text-amber-800">{name}</span>
+      {onAccept && (
+        <button
+          onClick={onAccept}
+          title={t('documents.acceptNew')}
+          className="flex h-4 w-4 shrink-0 items-center justify-center rounded-full bg-amber-100 text-amber-600 hover:bg-amber-200 hover:text-amber-800 transition-colors"
+        >
+          <Plus size={9} strokeWidth={3} />
+        </button>
+      )}
+      {onDismiss && (
+        <button
+          onClick={onDismiss}
+          title={t('common.discard')}
+          className="flex h-4 w-4 shrink-0 items-center justify-center rounded-full text-amber-400 hover:bg-amber-200 hover:text-amber-700 transition-colors"
+        >
+          <X size={9} strokeWidth={3} />
+        </button>
+      )}
+    </div>
+  );
+}
+
 // ─── Selectable field (with dropdown of existing options) ────────────────────
 
 function SelectableField({
@@ -628,12 +723,18 @@ function SelectableField({
   value,
   icon,
   options,
+  newSuggestion,
+  onAcceptNew,
+  onDismissNew,
   onSave,
 }: {
   label: string;
   value: string | null;
   icon?: React.ReactNode;
   options: string[];
+  newSuggestion?: string | null;
+  onAcceptNew?: () => void;
+  onDismissNew?: () => void;
   onSave: (v: string) => void;
 }) {
   const [editing, setEditing] = useState(false);
@@ -730,6 +831,14 @@ function SelectableField({
           <span className="truncate">{value || '—'}</span>
           <ChevronDown size={11} className="ml-2 shrink-0 text-gray-200 group-hover:text-gray-400 transition-colors" />
         </button>
+      )}
+      {/* New suggestion hint — shown when LLM proposed a value not yet in paperless */}
+      {!editing && newSuggestion && (
+        <NewSuggestionHint
+          name={newSuggestion}
+          onAccept={onAcceptNew}
+          onDismiss={onDismissNew}
+        />
       )}
     </div>
   );

--- a/default_prompts/tags.hbs
+++ b/default_prompts/tags.hbs
@@ -11,11 +11,13 @@ Current tags on the document:
 {{#if UseExistingOnly}}
 Rules:
 - You MUST only select tags from the "Available tags" list above — do not invent new tags
+- A document can have between 0 and 5 tags
 {{else}}
 Rules:
 - Prefer tags from the "Available tags" list; you may suggest new tag names if no existing tag fits
-{{/if}}
 - A document can have between 0 and 5 tags
+- You MUST always suggest exactly 2 new tag names that are NOT in the "Available tags" list above
+{{/if}}
 - Choose only tags that are clearly relevant
 - Return a JSON array of tag names, e.g. ["Invoice", "Tax"]
 - Do not include any explanation, only the JSON array

--- a/packages/shared/src/locales/de.json
+++ b/packages/shared/src/locales/de.json
@@ -82,6 +82,9 @@
         "jobFailed": "Fehlgeschlagen",
         "originalText": "Originaltext",
         "addTag": "Tag hinzufügen…",
+        "newBadge": "Neu",
+        "acceptNew": "Übernehmen — wird beim Anwenden in paperless-ngx erstellt",
+        "newSuggestionHint": "Vom KI vorgeschlagen — existiert noch nicht in paperless-ngx. Klicke +, um es hinzuzufügen.",
         "fields": {
             "title": "Titel",
             "tags": "Tags",

--- a/packages/shared/src/locales/en.json
+++ b/packages/shared/src/locales/en.json
@@ -82,6 +82,9 @@
         "jobFailed": "Failed",
         "originalText": "Original text",
         "addTag": "Add tag…",
+        "newBadge": "New",
+        "acceptNew": "Accept — will be created in paperless-ngx when applied",
+        "newSuggestionHint": "Suggested by AI — does not exist in paperless-ngx yet. Click + to include it.",
         "fields": {
             "title": "Title",
             "tags": "Tags",

--- a/packages/shared/src/schemas/api.schemas.ts
+++ b/packages/shared/src/schemas/api.schemas.ts
@@ -14,6 +14,9 @@ export const DocumentSuggestionsSchema = z.object({
         .array(z.object({ field: z.number(), value: z.union([z.string(), z.number(), z.boolean(), z.null()]) }))
         .optional(),
     summary: z.string().optional(),
+    newTags: z.array(z.string()).optional(),
+    newCorrespondent: z.string().nullable().optional(),
+    newDocumentType: z.string().nullable().optional(),
 });
 
 export const ApplySuggestionsRequestSchema = z.object({

--- a/packages/shared/src/types/pipeline.types.ts
+++ b/packages/shared/src/types/pipeline.types.ts
@@ -16,6 +16,12 @@ export interface DocumentSuggestions {
     createdDate?: string | null; // ISO date string
     customFields?: PaperlessCustomFieldValue[];
     summary?: string;
+    /** Tags suggested by the LLM that do not yet exist in paperless-ngx. User must accept them explicitly. */
+    newTags?: string[];
+    /** Correspondent suggested by the LLM that does not yet exist in paperless-ngx. */
+    newCorrespondent?: string | null;
+    /** Document type suggested by the LLM that does not yet exist in paperless-ngx. */
+    newDocumentType?: string | null;
 }
 
 // ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
This pull request introduces support for handling and displaying new, AI-suggested tags, correspondents, and document types that do not yet exist in the Paperless-ngx system. The backend and frontend have been updated to track, store, and allow user interaction with these "new" suggestions, ensuring that users can review and accept or dismiss them before they are created in Paperless. Additional improvements include schema changes, API enhancements, and UI updates to clearly surface these suggestions and streamline user workflows.

**Backend: New suggestion tracking and schema updates**
- The database schema for the `suggestions` table is extended to include `new_tags`, `new_correspondent`, and `new_document_type` fields, and the suggestion pipeline stages are updated to split new (not-yet-existing) values from existing ones for tags, correspondents, and document types. [[1]](diffhunk://#diff-115f4ea56612d7c1123fbc1a9c7cb3e664d3411f6906f0a5f758f053539b174cR53-R55) [[2]](diffhunk://#diff-115f4ea56612d7c1123fbc1a9c7cb3e664d3411f6906f0a5f758f053539b174cR82-R89) [[3]](diffhunk://#diff-cf118e957cab3dc2d4a6d93927c9d823ff500be7d29d635965fb390fb98f29e4R21-R23) [[4]](diffhunk://#diff-5ded7c1cafec5bce439cd9317f6e8e116f01ca19dbc58442a4dd226600017ae1R41-R58) [[5]](diffhunk://#diff-b423c5f3576d1c2ade8266d5d16ce5cc626af248c3a1f5802e92a33735e0f874R35-R52) [[6]](diffhunk://#diff-a0ec0d79dd067f51f9dcdda542befc26b230a8ca2a56b1969e8c9f9f1de445b6R34-R51)
- The API and job worker logic are updated to read and write these new fields, and the shared API schema is extended accordingly. [[1]](diffhunk://#diff-532e80f8d81e0bb19c9df66a0bcfdab857b77091e2c112d8f5e119108c061fd6R82-R84) [[2]](diffhunk://#diff-99ba8d9ae13e03db906355b64bd7de03c69fe8eb76339215344c425151ff061bR92-R94) [[3]](diffhunk://#diff-99ba8d9ae13e03db906355b64bd7de03c69fe8eb76339215344c425151ff061bR196-R198) [[4]](diffhunk://#diff-936f67075dd2d33661169b365f4c40db095813a8f8bbad0c8396ba178041173eR17-R19)

**Frontend: User interface for new suggestions**
- The document suggestions panel now displays new (not-yet-existing) tags, correspondents, and document types with clear visual cues and provides controls for users to accept or dismiss each suggestion individually. [[1]](diffhunk://#diff-788f45d03315144a4d5ebf33b527fb1312eb7371a5c96349c4d8c71870efc472R473-R501) [[2]](diffhunk://#diff-788f45d03315144a4d5ebf33b527fb1312eb7371a5c96349c4d8c71870efc472R537-R539) [[3]](diffhunk://#diff-788f45d03315144a4d5ebf33b527fb1312eb7371a5c96349c4d8c71870efc472R549-R551) [[4]](diffhunk://#diff-788f45d03315144a4d5ebf33b527fb1312eb7371a5c96349c4d8c71870efc472R587-R612) [[5]](diffhunk://#diff-788f45d03315144a4d5ebf33b527fb1312eb7371a5c96349c4d8c71870efc472R685-R737) [[6]](diffhunk://#diff-788f45d03315144a4d5ebf33b527fb1312eb7371a5c96349c4d8c71870efc472R835-R842)
- Translations and UI text are added for new suggestion badges, tooltips, and action buttons. [[1]](diffhunk://#diff-26695c068cbce05013e336106ea4be81d404622119c44b52eaf9cb2f42583c40R85-R87) [[2]](diffhunk://#diff-3573c2f1681e7def526879994d766f073ad4d80205395636621acf9c4c844fc7R85-R87)

**Paperless integration improvements**
- The Paperless client now includes an `ensureDocumentType` method to create document types on demand, and the suggestion application logic is updated to use it, enabling seamless creation of new document types when accepted by the user. [[1]](diffhunk://#diff-a6ed567e2708ff1b65bd942bd081f74f0ddd3a822b9d3e884a113a5c394a77b9L129-R134) [[2]](diffhunk://#diff-a6ed567e2708ff1b65bd942bd081f74f0ddd3a822b9d3e884a113a5c394a77b9L153-R159)

**Prompt adjustments**
- The tags prompt template is updated to clarify the rules for suggesting new tags, including instructing the AI to always suggest exactly two new tag names when allowed.

**Miscellaneous**
- Minor UX tweaks (e.g., card overflow behavior) and LLM warmup improvements are included. [[1]](diffhunk://#diff-788f45d03315144a4d5ebf33b527fb1312eb7371a5c96349c4d8c71870efc472L185-R189) [[2]](diffhunk://#diff-8554514f85a23455a048ba3f825327e9f139755c1460811ae19509053bc73e29L123-R129)

These changes collectively enable a more interactive and user-friendly workflow for reviewing and incorporating AI-suggested metadata that extends beyond the current Paperless-ngx dataset.