### PR TITLE
Add context window size configuration for Ollama model warmup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,9 @@ OLLAMA_HOST=http://ollama:11434/api
 # Large models (e.g. qwen3:14b, 8+ GiB) can take several minutes to cold-load
 # from disk into GPU memory. Set to 0 to wait forever.
 # OLLAMA_REQUEST_TIMEOUT_SECONDS=600
+# Context window size (num_ctx) passed to Ollama (default: 0 = model default).
+# Set to 131072 for a 130k context window.
+# OLLAMA_CONTEXT_LENGTH=131072
 # Required for OpenAI / Anthropic / Mistral
 # OPENAI_API_KEY=
 # ANTHROPIC_API_KEY=

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -82,6 +82,7 @@ async function bootstrap() {
             model: config.LLM_MODEL,
             warmupTimeoutMs: (config.OLLAMA_REQUEST_TIMEOUT_SECONDS ?? 600) * 1000,
             sseService: sse,
+            ...(config.OLLAMA_CONTEXT_LENGTH > 0 && { numCtx: config.OLLAMA_CONTEXT_LENGTH }),
         });
         log.info({ model: config.LLM_MODEL }, 'Ollama warmup service created (starts on first job enqueue)');
     }

--- a/apps/api/src/providers/llm/ollama-warmup.service.ts
+++ b/apps/api/src/providers/llm/ollama-warmup.service.ts
@@ -30,6 +30,11 @@ export interface OllamaWarmupOptions {
     retryIntervalMs?: number;
     /** Optional SSE service to broadcast warmup state to connected clients. */
     sseService?: SseService;
+    /**
+     * Context window size to load the model with (num_ctx).
+     * When undefined / 0, Ollama uses the model's built-in default.
+     */
+    numCtx?: number;
 }
 
 export class OllamaWarmupService extends EventEmitter {
@@ -122,6 +127,7 @@ export class OllamaWarmupService extends EventEmitter {
                         model,
                         prompt: '',  // empty prompt → no tokens generated, just loads the model
                         stream: false,
+                        ...(this.opts.numCtx && { options: { num_ctx: this.opts.numCtx } }),
                     }),
                     // keep_alive is intentionally omitted — Ollama uses its own
                     // OLLAMA_KEEP_ALIVE server env var, which is the right place to set it.

--- a/apps/api/src/providers/llm/ollama.provider.ts
+++ b/apps/api/src/providers/llm/ollama.provider.ts
@@ -14,10 +14,12 @@ export class OllamaProvider implements TextLLMProvider, VisionLLMProvider {
     private readonly client: ReturnType<typeof createOllama>;
     private readonly defaultTemperature: number | undefined;
     private readonly requestTimeoutMs: number;
+    private readonly numCtx: number | undefined;
 
-    constructor(config: Pick<AppConfig, 'OLLAMA_HOST' | 'LLM_MODEL' | 'OLLAMA_TEMPERATURE' | 'OLLAMA_REQUEST_TIMEOUT_SECONDS'>) {
+    constructor(config: Pick<AppConfig, 'OLLAMA_HOST' | 'LLM_MODEL' | 'OLLAMA_TEMPERATURE' | 'OLLAMA_REQUEST_TIMEOUT_SECONDS' | 'OLLAMA_CONTEXT_LENGTH'>) {
         this.modelName = config.LLM_MODEL;
         this.defaultTemperature = config.OLLAMA_TEMPERATURE;
+        this.numCtx = config.OLLAMA_CONTEXT_LENGTH > 0 ? config.OLLAMA_CONTEXT_LENGTH : undefined;
         const timeoutSeconds = config.OLLAMA_REQUEST_TIMEOUT_SECONDS ?? 600;
         // Clamp to MAX_SAFE_TIMEOUT_MS to prevent setTimeout integer overflow.
         this.requestTimeoutMs = timeoutSeconds === 0 ? 0 : Math.min(timeoutSeconds * 1000, MAX_SAFE_TIMEOUT_MS);
@@ -47,7 +49,7 @@ export class OllamaProvider implements TextLLMProvider, VisionLLMProvider {
     async generateText(systemPrompt: string, userPrompt: string, options?: LLMOptions): Promise<string> {
         const temperature = options?.temperature ?? this.defaultTemperature;
         const result = await generateText({
-            model: this.client(this.modelName),
+            model: this.client(this.modelName, { ...(this.numCtx !== undefined && { numCtx: this.numCtx }) }),
             system: systemPrompt,
             prompt: userPrompt,
             maxTokens: options?.maxTokens,
@@ -68,7 +70,7 @@ export class OllamaProvider implements TextLLMProvider, VisionLLMProvider {
 
         const temperature = options?.temperature ?? this.defaultTemperature;
         const result = await generateText({
-            model: this.client(this.modelName),
+            model: this.client(this.modelName, { ...(this.numCtx !== undefined && { numCtx: this.numCtx }) }),
             messages: [
                 { role: 'user', content: [{ type: 'text', text: prompt }, ...content] },
             ],


### PR DESCRIPTION
This pull request adds support for configuring the context window size (num_ctx) for Ollama models via an environment variable. This allows users to specify a custom context length, such as 131,072 tokens for large-context models, improving flexibility and control over model behavior. The changes propagate this configuration through the API and provider layers, ensuring that the context window size is used consistently when initializing and warming up Ollama models.

**Environment variable and configuration changes:**

* Added the `OLLAMA_CONTEXT_LENGTH` environment variable to `.env.example`, allowing users to specify the context window size for Ollama models.

**API and service integration:**

* Passed the `OLLAMA_CONTEXT_LENGTH` configuration to the Ollama warmup service in `apps/api/src/main.ts`, ensuring the context window size is used during model warmup.
* Updated the `OllamaWarmupOptions` interface and warmup logic to accept and utilize the `numCtx` (context window size) parameter when loading models. [[1]](diffhunk://#diff-8554514f85a23455a048ba3f825327e9f139755c1460811ae19509053bc73e29R33-R37) [[2]](diffhunk://#diff-8554514f85a23455a048ba3f825327e9f139755c1460811ae19509053bc73e29R130)

**Provider layer updates:**

* Modified the `OllamaProvider` class to read and store the `OLLAMA_CONTEXT_LENGTH` value, passing it to the Ollama client when generating text or chat completions. [[1]](diffhunk://#diff-a50cdf618b143390259d9adaf95e3ce9ef0b9d94eed7d74abd0ce9d21231262fR17-R22) [[2]](diffhunk://#diff-a50cdf618b143390259d9adaf95e3ce9ef0b9d94eed7d74abd0ce9d21231262fL50-R52) [[3]](diffhunk://#diff-a50cdf618b143390259d9adaf95e3ce9ef0b9d94eed7d74abd0ce9d21231262fL71-R73)